### PR TITLE
Add missing commands

### DIFF
--- a/features/keyspam.cpp
+++ b/features/keyspam.cpp
@@ -18,6 +18,12 @@ CKeySpam g_KeySpam;
 //-----------------------------------------------------------------------------
 //-----------------------------------------------------------------------------
 
+CON_COMMAND_EXTERN(sc_spam_hold_mode, ConCommand_SpamHoldMode, "Toggle spam hold mode")
+{
+	Msg(g_Config.cvars.keyspam_hold_mode ? "Hold Mode disabled\n" : "Hold Mode enabled\n");
+	g_Config.cvars.keyspam_hold_mode = !g_Config.cvars.keyspam_hold_mode;
+}
+
 CON_COMMAND_EXTERN(sc_spam_use, ConCommand_UseSpam, "Toggle E spam")
 {
 	g_pEngineFuncs->ClientCmd("-use");

--- a/features/misc.cpp
+++ b/features/misc.cpp
@@ -230,6 +230,24 @@ CON_COMMAND_EXTERN_NO_WRAPPER(sc_auto_ceil_clipping, ConCommand_AutoCeilClipping
 	g_Config.cvars.auto_ceil_clipping = !g_Config.cvars.auto_ceil_clipping;
 }
 
+CON_COMMAND_EXTERN_NO_WRAPPER(sc_rotate_dead_body, ConCommand_RotateDeadBody, "Toggle rotate dead body")
+{
+	Msg(g_Config.cvars.rotate_dead_body ? "Rotate Dead Body disabled\n" : "Rotate Dead Body enabled\n");
+	g_Config.cvars.rotate_dead_body = !g_Config.cvars.rotate_dead_body;
+}
+
+CON_COMMAND_EXTERN_NO_WRAPPER(sc_tertiary_attack_glitch, ConCommand_TertiaryAttackGlitch, "Toggle tertiary attack glitch")
+{
+	Msg(g_Config.cvars.tertiary_attack_glitch ? "Tertiary Attack Glitch disabled\n" : "Tertiary Attack Glitch enabled\n");
+	g_Config.cvars.tertiary_attack_glitch = !g_Config.cvars.tertiary_attack_glitch;
+}
+
+CON_COMMAND_EXTERN_NO_WRAPPER(sc_quake_guns, ConCommand_QuakeGuns, "Toggle Quake guns")
+{
+	Msg(g_Config.cvars.quake_guns ? "Quake Guns disabled\n" : "Quake Guns enabled\n");
+	g_Config.cvars.quake_guns = !g_Config.cvars.quake_guns;
+}
+
 CON_COMMAND_EXTERN_NO_WRAPPER(sc_selfsink, ConCommand_AutoSelfSink, "Perform self sink")
 {
 	if ( Client()->IsDead() )
@@ -279,6 +297,12 @@ CON_COMMAND_EXTERN_NO_WRAPPER(sc_drop_empty_weapon, ConCommand_DropEmptyWeapon, 
 			}
 		}
 	}
+}
+
+CON_COMMAND_EXTERN_NO_WRAPPER(sc_first_person_roaming, ConCommand_FirstPersonRoaming, "Toggle first-person roaming")
+{
+	Msg(g_Config.cvars.fp_roaming ? "First-Person Roaming disabled\n" : "First-Person Roaming enabled\n");
+	g_Config.cvars.fp_roaming = !g_Config.cvars.fp_roaming;
 }
 
 CON_COMMAND(sc_stick, "Follow a player")


### PR DESCRIPTION
I can't click the UI with RInput injected. So, here are some of the commands I added

Utility > Player
- `sc_rotate_dead_body`
- `sc_tertiary_attack_glitch`
- `sc_quake_guns`

Utility > Spammer
- `sc_spam_hold_mode`

Utility > Camera
- `sc_first_person_roaming`